### PR TITLE
Fix app dual space crash

### DIFF
--- a/killer/src/main/java/bin/mt/signature/KillerApplication.java
+++ b/killer/src/main/java/bin/mt/signature/KillerApplication.java
@@ -136,7 +136,7 @@ public class KillerApplication extends Application {
             return;
         }
         File apkFile = new File(apkPath);
-        File repFile = new File("/data/data/" + packageName + "/origin.apk");
+        File repFile = new File(Environment.getDataDirectory().getPath() + packageName + "/origin.apk");
         try (ZipFile zipFile = new ZipFile(apkFile)) {
             String name = "assets/SignatureKiller/origin.apk";
             ZipEntry entry = zipFile.getEntry(name);


### PR DESCRIPTION
In systems like MIUI, XOS, when the user uses the built-in dual space (or second user) , the application crashes, cuz the data directory is /data/user/999/

Environment.getDataDirectory().getPath() solves this crash